### PR TITLE
[V3] Unable to select files from Recent (Android 11+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.2
+* [#3](https://github.com/locusview/cordova-plugin-filepath/pull/3)
+
 # 1.6.1
 * [#1](https://github.com/locusview/cordova-plugin-filepath/pull/1)
 * [#2](https://github.com/locusview/cordova-plugin-filepath/pull/2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filepath",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filepath",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Resolve native file paths from content URLs for Cordova platforms",
   "cordova": {
     "id": "cordova-plugin-filepath",

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
   under the License.
 -->
 
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-filepath" version="1.6.1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-filepath" version="1.6.2">
     <name>cordova-plugin-filepath</name>
     <description>Resolve native file paths from content URLs for Cordova platforms</description>
     <license>Apache 2.0</license>
@@ -43,6 +43,7 @@
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+            <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
         </config-file>
 
         <source-file src="src/android/FilePath.java" target-dir="src/com/hiddentao/cordova/filepath"/>


### PR DESCRIPTION
This PR adds functionality which checks whether we have the necessary permission for devices running Android 11+ to access content providers in the media directory.
If we don't have the permission, the plugin will launch the intent requesting it and the call will resolve if granted. 
The call will reject as normal if the permission is not granted.
Devices below Android 11, will function as normal. 